### PR TITLE
Fix/custom style provider

### DIFF
--- a/Sources/XS2AiOS/Resources/ResultCell.xib
+++ b/Sources/XS2AiOS/Resources/ResultCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -27,6 +27,7 @@
                 </subviews>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <connections>
                 <outlet property="resultTextLabel" destination="D9r-UG-KDb" id="CI4-Zp-fcJ"/>
             </connections>

--- a/Sources/XS2AiOS/Utils/AutocompleteView.swift
+++ b/Sources/XS2AiOS/Utils/AutocompleteView.swift
@@ -135,6 +135,7 @@ class AutocompleteView: UIViewController, UITableViewDelegate, UITableViewDataSo
 	init(countryId: String, label: String, prefilledText: String?) {
 		self.countryId = countryId
 		self.label.text = label
+        self.infoLabel.textColor = XS2AiOS.shared.styleProvider.textColor
 		self.infoLabel.text = Strings.AutocompleteView.notice
 		self.infoLabel.numberOfLines = 3
 		self.searchField.autocorrectionType = .no
@@ -175,6 +176,7 @@ class AutocompleteView: UIViewController, UITableViewDelegate, UITableViewDataSo
 		}
 
 		view.backgroundColor = XS2AiOS.shared.styleProvider.backgroundColor
+        resultTable.backgroundColor = .clear
 		searchField.addTarget(self, action: #selector(self.textFieldDidChange(_:)), for: .editingChanged)
 		resultTable.separatorInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
 

--- a/Sources/XS2AiOS/Utils/AutocompleteView.swift
+++ b/Sources/XS2AiOS/Utils/AutocompleteView.swift
@@ -135,7 +135,7 @@ class AutocompleteView: UIViewController, UITableViewDelegate, UITableViewDataSo
 	init(countryId: String, label: String, prefilledText: String?) {
 		self.countryId = countryId
 		self.label.text = label
-        self.infoLabel.textColor = XS2AiOS.shared.styleProvider.textColor
+	        self.infoLabel.textColor = XS2AiOS.shared.styleProvider.textColor
 		self.infoLabel.text = Strings.AutocompleteView.notice
 		self.infoLabel.numberOfLines = 3
 		self.searchField.autocorrectionType = .no
@@ -176,7 +176,7 @@ class AutocompleteView: UIViewController, UITableViewDelegate, UITableViewDataSo
 		}
 
 		view.backgroundColor = XS2AiOS.shared.styleProvider.backgroundColor
-        resultTable.backgroundColor = .clear
+	        resultTable.backgroundColor = .clear
 		searchField.addTarget(self, action: #selector(self.textFieldDidChange(_:)), for: .editingChanged)
 		resultTable.separatorInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
 


### PR DESCRIPTION
- Updated Background Color for the **ResultCell** and the **AutocompletedView** **resultTable** with _clear color_, to be able to display a custom Background Color that is anything other than white
 
- Updated **AutocompletedView** **InfoLabel** with _XS2AiOS.shared.styleProvider.textColor_ as Source