### PR TITLE
Make library type dynamic

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,7 @@ let package = Package(
 	products: [
 		.library(
 			name: "XS2AiOS",
+            type: .dynamic,
 			targets: ["XS2AiOS"]),
 	],
 	dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
 	products: [
 		.library(
 			name: "XS2AiOS",
-            type: .dynamic,
+			type: .dynamic,
 			targets: ["XS2AiOS"]),
 	],
 	dependencies: [


### PR DESCRIPTION
In order to be able to include the Swift Package in nested workspaces, it is necessary to mark it as `type: .dynamic` in the Package.swift.