### PR TITLE
Add loading state provider

### DIFF
--- a/Sources/XS2AiOS/Extensions/LoadingDialog+ViewContoller.swift
+++ b/Sources/XS2AiOS/Extensions/LoadingDialog+ViewContoller.swift
@@ -8,6 +8,16 @@ struct ProgressDialog {
 
 extension UIViewController {
 	func showLoadingIndicator(title: String = "", message: String = "") {
+        XS2AiOS.shared.loadingStateProvider.showLoadingIndicator(title: title, message: message, over: self)
+    }
+
+    func hideLoadingIndicator() {
+        XS2AiOS.shared.loadingStateProvider.hideLoadingIndicator(over: self)
+    }
+}
+
+class XS2ALoadingStateProvider: LoadingStateProvider {
+    func showLoadingIndicator(title: String, message: String, over viewController: UIViewController) {
 		ProgressDialog.alert = UIAlertController(title: title.isEmpty ? nil : title, message: message, preferredStyle: .alert)
 		
 		if (!title.isEmpty) {
@@ -59,13 +69,12 @@ extension UIViewController {
 		}
 		
 		ProgressDialog.indicatorView.startAnimating()
-		present(ProgressDialog.alert, animated: true, completion: nil)
+        viewController.present(ProgressDialog.alert, animated: true, completion: nil)
 	}
 
-	func hideLoadingIndicator(){
+    func hideLoadingIndicator(over viewController: UIViewController) {
 		ProgressDialog.alert.dismiss(animated: true) {
 			ProgressDialog.indicatorView.stopAnimating()
 		}
-
 	}
 }

--- a/Sources/XS2AiOS/Extensions/LoadingDialog+ViewContoller.swift
+++ b/Sources/XS2AiOS/Extensions/LoadingDialog+ViewContoller.swift
@@ -8,16 +8,16 @@ struct ProgressDialog {
 
 extension UIViewController {
 	func showLoadingIndicator(title: String = "", message: String = "") {
-        XS2AiOS.shared.loadingStateProvider.showLoadingIndicator(title: title, message: message, over: self)
-    }
+		XS2AiOS.shared.loadingStateProvider.showLoadingIndicator(title: title, message: message, over: self)
+	}
 
-    func hideLoadingIndicator() {
-        XS2AiOS.shared.loadingStateProvider.hideLoadingIndicator(over: self)
-    }
+	func hideLoadingIndicator() {
+		XS2AiOS.shared.loadingStateProvider.hideLoadingIndicator(over: self)
+	}
 }
 
 class XS2ALoadingStateProvider: LoadingStateProvider {
-    func showLoadingIndicator(title: String, message: String, over viewController: UIViewController) {
+	func showLoadingIndicator(title: String, message: String, over viewController: UIViewController) {
 		ProgressDialog.alert = UIAlertController(title: title.isEmpty ? nil : title, message: message, preferredStyle: .alert)
 		
 		if (!title.isEmpty) {
@@ -69,10 +69,10 @@ class XS2ALoadingStateProvider: LoadingStateProvider {
 		}
 		
 		ProgressDialog.indicatorView.startAnimating()
-        viewController.present(ProgressDialog.alert, animated: true, completion: nil)
+		viewController.present(ProgressDialog.alert, animated: true, completion: nil)
 	}
 
-    func hideLoadingIndicator(over viewController: UIViewController) {
+	func hideLoadingIndicator(over viewController: UIViewController) {
 		ProgressDialog.alert.dismiss(animated: true) {
 			ProgressDialog.indicatorView.stopAnimating()
 		}

--- a/Sources/XS2AiOS/Protocols/LoadingStateProvider.swift
+++ b/Sources/XS2AiOS/Protocols/LoadingStateProvider.swift
@@ -1,0 +1,6 @@
+import UIKit
+
+public protocol LoadingStateProvider {
+    func showLoadingIndicator(title: String, message: String, over viewController: UIViewController)
+    func hideLoadingIndicator(over viewController: UIViewController)
+}

--- a/Sources/XS2AiOS/Protocols/LoadingStateProvider.swift
+++ b/Sources/XS2AiOS/Protocols/LoadingStateProvider.swift
@@ -1,6 +1,6 @@
 import UIKit
 
 public protocol LoadingStateProvider {
-    func showLoadingIndicator(title: String, message: String, over viewController: UIViewController)
-    func hideLoadingIndicator(over viewController: UIViewController)
+	func showLoadingIndicator(title: String, message: String, over viewController: UIViewController)
+	func hideLoadingIndicator(over viewController: UIViewController)
 }

--- a/Sources/XS2AiOS/XS2AiOS.swift
+++ b/Sources/XS2AiOS/XS2AiOS.swift
@@ -6,6 +6,7 @@ public class XS2AiOS {
 
 	public var configuration: Configuration
 	public let styleProvider: StyleProvider
+    public let loadingStateProvider: LoadingStateProvider
 	public let keychain: Keychain
 	let apiService: APIService
 	
@@ -19,10 +20,12 @@ public class XS2AiOS {
 	 - Parameters:
 	  - configuration: The Configuration including the wizardSessionKey for the session to be initialized
 	  - styleProvider: The StyleProvider to be used
+      - loadingStateProvider: The LoadingStateProvider to be used
 	*/
-	init(configuration: Configuration, styleProvider: StyleProvider) {
+	init(configuration: Configuration, styleProvider: StyleProvider, loadingStateProvider: LoadingStateProvider = XS2ALoadingStateProvider()) {
 		self.configuration = configuration
 		self.styleProvider = styleProvider
+        self.loadingStateProvider = loadingStateProvider
 		self.apiService = APIService(wizardSessionKey: configuration.wizardSessionKey, baseURL: configuration.baseURL)
 		
 		self.currentStep = nil
@@ -38,9 +41,17 @@ public class XS2AiOS {
 		}
 	}
 	
-	public static func configure(withConfig configuration: Configuration, withStyle styleProvider: StyleProvider) {
-		_shared = XS2AiOS(configuration: configuration, styleProvider: styleProvider)
+    public static func configure(withConfig configuration: Configuration, withStyle styleProvider: StyleProvider) {
+		_shared = XS2AiOS(configuration: configuration, styleProvider: styleProvider, loadingStateProvider: XS2ALoadingStateProvider())
 	}
+
+    public static func configure(
+        withConfig configuration: Configuration,
+        withStyle styleProvider: StyleProvider,
+        withLoading loadingStateProvider: LoadingStateProvider
+    ) {
+        _shared = XS2AiOS(configuration: configuration, styleProvider: styleProvider, loadingStateProvider: loadingStateProvider)
+    }
 	
 	public static var shared: XS2AiOS {
 		guard let shared = _shared else {

--- a/Sources/XS2AiOS/XS2AiOS.swift
+++ b/Sources/XS2AiOS/XS2AiOS.swift
@@ -6,7 +6,7 @@ public class XS2AiOS {
 
 	public var configuration: Configuration
 	public let styleProvider: StyleProvider
-    public let loadingStateProvider: LoadingStateProvider
+	public let loadingStateProvider: LoadingStateProvider
 	public let keychain: Keychain
 	let apiService: APIService
 	
@@ -25,7 +25,7 @@ public class XS2AiOS {
 	init(configuration: Configuration, styleProvider: StyleProvider, loadingStateProvider: LoadingStateProvider = XS2ALoadingStateProvider()) {
 		self.configuration = configuration
 		self.styleProvider = styleProvider
-        self.loadingStateProvider = loadingStateProvider
+		self.loadingStateProvider = loadingStateProvider
 		self.apiService = APIService(wizardSessionKey: configuration.wizardSessionKey, baseURL: configuration.baseURL)
 		
 		self.currentStep = nil
@@ -41,17 +41,17 @@ public class XS2AiOS {
 		}
 	}
 	
-    public static func configure(withConfig configuration: Configuration, withStyle styleProvider: StyleProvider) {
+	public static func configure(withConfig configuration: Configuration, withStyle styleProvider: StyleProvider) {
 		_shared = XS2AiOS(configuration: configuration, styleProvider: styleProvider, loadingStateProvider: XS2ALoadingStateProvider())
 	}
 
-    public static func configure(
-        withConfig configuration: Configuration,
-        withStyle styleProvider: StyleProvider,
-        withLoading loadingStateProvider: LoadingStateProvider
-    ) {
-        _shared = XS2AiOS(configuration: configuration, styleProvider: styleProvider, loadingStateProvider: loadingStateProvider)
-    }
+	public static func configure(
+		withConfig configuration: Configuration,
+		withStyle styleProvider: StyleProvider,
+		withLoading loadingStateProvider: LoadingStateProvider
+	) {
+		_shared = XS2AiOS(configuration: configuration, styleProvider: styleProvider, loadingStateProvider: loadingStateProvider)
+	}
 	
 	public static var shared: XS2AiOS {
 		guard let shared = _shared else {


### PR DESCRIPTION
Add possibility to replace the loading state with a custom implementation. 
The goal is to have the same loading style as the other parts of the app that uses the SDK.

This change exposes the LoadingStateProvider protocol with two simple methods to show and hide the loading.
Adds the backward compatible implementation and use it as default loading provider.