### PR TITLE
Extend the Style Provider to define the color and width of the border around the text fields and buttons

### DIFF
--- a/Sources/XS2AiOS/Base Elements/SelectTextfield.swift
+++ b/Sources/XS2AiOS/Base Elements/SelectTextfield.swift
@@ -9,6 +9,8 @@ class SelectTextfield: UITextField, UITextFieldDelegate {
 		self.tintColor = XS2AiOS.shared.styleProvider.tintColor
 		self.backgroundColor = XS2AiOS.shared.styleProvider.inputBackgroundColor
 		self.layer.cornerRadius = XS2AiOS.shared.styleProvider.inputBorderRadius
+		self.layer.borderWidth = XS2AiOS.shared.styleProvider.inputBorderWidth
+		self.layer.borderColor = XS2AiOS.shared.styleProvider.inputBorderColor.cgColor
 		self.font = XS2AiOS.shared.styleProvider.font.getFont(ofSize: 20, ofWeight: nil)
 		self.textColor = XS2AiOS.shared.styleProvider.inputTextColor
 		self.heightAnchor.constraint(equalToConstant: 50).isActive = true
@@ -53,14 +55,15 @@ class SelectTextfield: UITextField, UITextFieldDelegate {
 	func styleTextfield(style: TextFieldStyles) {
 		switch style {
 		case .error:
-			self.layer.borderWidth = 2
+			self.layer.borderWidth = XS2AiOS.shared.styleProvider.inputBorderWidthActive
 			self.layer.borderColor = XS2AiOS.shared.styleProvider.errorStyle.backgroundColor.cgColor
 			self.layer.add(getBorderWidthAnimation(type: .didStart), forKey: "Width")
 		case .normal:
-			if self.layer.borderWidth != 0 {
-				self.layer.borderWidth = 0
+			if self.layer.borderWidth != XS2AiOS.shared.styleProvider.inputBorderWidth {
+				self.layer.borderWidth = XS2AiOS.shared.styleProvider.inputBorderWidth
 				self.layer.add(getBorderWidthAnimation(type: .didEnd), forKey: "Width")
 			}
+			self.layer.borderColor = XS2AiOS.shared.styleProvider.inputBorderColor.cgColor
 		}
 	}
 	
@@ -84,19 +87,22 @@ class SelectTextfield: UITextField, UITextFieldDelegate {
 
 	
 	func textFieldDidBeginEditing(_ textField: UITextField) {
-		if self.layer.borderWidth != 2 {
-			self.layer.borderWidth = 2
-			self.layer.add(getBorderWidthAnimation(type: .didStart), forKey: "Width")
+		if self.layer.borderWidth != XS2AiOS.shared.styleProvider.inputBorderWidthActive ||
+			self.layer.borderColor != XS2AiOS.shared.styleProvider.tintColor.cgColor {
+			self.layer.borderColor = XS2AiOS.shared.styleProvider.tintColor.cgColor
+			self.layer.borderWidth = XS2AiOS.shared.styleProvider.inputBorderWidthActive
+			self.layer.add(getBorderAnimation(type: .didStart), forKey: "Border")
 		}
-		
-		self.layer.borderColor = XS2AiOS.shared.styleProvider.tintColor.cgColor
+
 		self.rightView?.tintColor = XS2AiOS.shared.styleProvider.tintColor
 	}
 	
 	func textFieldDidEndEditing(_ textField: UITextField) {
-		if self.layer.borderWidth != 0 {
-			self.layer.borderWidth = 0
-			self.layer.add(getBorderWidthAnimation(type: .didEnd), forKey: "Width")
+		if self.layer.borderWidth != XS2AiOS.shared.styleProvider.inputBorderWidth ||
+			self.layer.borderColor != XS2AiOS.shared.styleProvider.inputBorderColor.cgColor {
+			self.layer.borderWidth = XS2AiOS.shared.styleProvider.inputBorderWidth
+			self.layer.borderColor = XS2AiOS.shared.styleProvider.inputBorderColor.cgColor
+			self.layer.add(getBorderAnimation(type: .didEnd), forKey: "Border")
 		}
 
 		self.rightView?.tintColor = XS2AiOS.shared.styleProvider.placeholderColor

--- a/Sources/XS2AiOS/Base Elements/Textfield.swift
+++ b/Sources/XS2AiOS/Base Elements/Textfield.swift
@@ -13,6 +13,8 @@ class Textfield: XS2ATextfield, UITextFieldDelegate {
 		self.tintColor = XS2AiOS.shared.styleProvider.tintColor
 		self.backgroundColor = XS2AiOS.shared.styleProvider.inputBackgroundColor
 		self.layer.cornerRadius = XS2AiOS.shared.styleProvider.inputBorderRadius
+		self.layer.borderWidth = XS2AiOS.shared.styleProvider.inputBorderWidth
+		self.layer.borderColor = XS2AiOS.shared.styleProvider.inputBorderColor.cgColor
 		self.font = XS2AiOS.shared.styleProvider.font.getFont(ofSize: 20, ofWeight: nil)
 		self.textColor = XS2AiOS.shared.styleProvider.inputTextColor
 		self.heightAnchor.constraint(equalToConstant: 50).isActive = true
@@ -50,17 +52,18 @@ class Textfield: XS2ATextfield, UITextFieldDelegate {
 	}
 	
 	func textFieldDidBeginEditing(_ textField: UITextField) {
-		if self.layer.borderWidth != 2 {
-			self.layer.borderWidth = 2
-			self.layer.add(getBorderWidthAnimation(type: .didStart), forKey: "Width")
+		if self.layer.borderWidth != XS2AiOS.shared.styleProvider.inputBorderWidthActive ||
+			self.layer.borderColor != XS2AiOS.shared.styleProvider.tintColor.cgColor {
+			self.layer.borderColor = XS2AiOS.shared.styleProvider.tintColor.cgColor
+			self.layer.borderWidth = XS2AiOS.shared.styleProvider.inputBorderWidthActive
+			self.layer.add(getBorderAnimation(type: .didStart), forKey: "Border")
 		}
-
-		self.layer.borderColor = XS2AiOS.shared.styleProvider.tintColor.cgColor
 	}
 	
 	func textFieldDidEndEditing(_ textField: UITextField) {
-		self.layer.borderWidth = 0
-		self.layer.add(getBorderWidthAnimation(type: .didEnd), forKey: "Width")
+		self.layer.borderWidth = XS2AiOS.shared.styleProvider.inputBorderWidth
+		self.layer.borderColor = XS2AiOS.shared.styleProvider.inputBorderColor.cgColor
+		self.layer.add(getBorderAnimation(type: .didEnd), forKey: "Border")
 	}
 	
 	func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {

--- a/Sources/XS2AiOS/Base Elements/TriggerTextfield.swift
+++ b/Sources/XS2AiOS/Base Elements/TriggerTextfield.swift
@@ -9,6 +9,8 @@ class TriggerTextfield: XS2ATextfield, UITextFieldDelegate {
 		self.tintColor = XS2AiOS.shared.styleProvider.tintColor
 		self.backgroundColor = XS2AiOS.shared.styleProvider.inputBackgroundColor
 		self.layer.cornerRadius = XS2AiOS.shared.styleProvider.inputBorderRadius
+		self.layer.borderWidth = XS2AiOS.shared.styleProvider.inputBorderWidth
+		self.layer.borderColor = XS2AiOS.shared.styleProvider.inputBorderColor.cgColor
 		self.font = XS2AiOS.shared.styleProvider.font.getFont(ofSize: 20, ofWeight: nil)
 		self.textColor = XS2AiOS.shared.styleProvider.inputTextColor
 		self.heightAnchor.constraint(equalToConstant: 50).isActive = true
@@ -60,18 +62,21 @@ class TriggerTextfield: XS2ATextfield, UITextFieldDelegate {
 
 	
 	func textFieldDidBeginEditing(_ textField: UITextField) {
-		if self.layer.borderWidth != 2 {
-			self.layer.borderWidth = 2
-			self.layer.add(getBorderWidthAnimation(type: .didStart), forKey: "Width")
+		if self.layer.borderWidth != XS2AiOS.shared.styleProvider.inputBorderWidthActive ||
+			self.layer.borderColor != XS2AiOS.shared.styleProvider.tintColor.cgColor {
+			self.layer.borderWidth = XS2AiOS.shared.styleProvider.inputBorderWidthActive
+			self.layer.add(getBorderAnimation(type: .didStart), forKey: "Border")
 		}
-		
+
+		self.layer.borderWidth = XS2AiOS.shared.styleProvider.inputBorderWidthActive
 		self.layer.borderColor = XS2AiOS.shared.styleProvider.tintColor.cgColor
 		self.leftView?.tintColor = XS2AiOS.shared.styleProvider.tintColor
 	}
 	
 	func textFieldDidEndEditing(_ textField: UITextField) {
-		self.layer.borderWidth = 0
-		self.layer.add(getBorderWidthAnimation(type: .didEnd), forKey: "Width")
+		self.layer.borderWidth = XS2AiOS.shared.styleProvider.inputBorderWidth
+		self.layer.borderColor = XS2AiOS.shared.styleProvider.inputBorderColor.cgColor
+		self.layer.add(getBorderAnimation(type: .didEnd), forKey: "Border")
 	}
 	
 	func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {

--- a/Sources/XS2AiOS/Extensions/ButtonExtension.swift
+++ b/Sources/XS2AiOS/Extensions/ButtonExtension.swift
@@ -16,27 +16,27 @@ enum XS2AButtonType {
 extension UIButton {
 	static func make(buttonType: XS2AButtonType) -> UIButton {
 		let button = UIButton()
-		
+
+		let style: XS2AiOS.ButtonStyle
 		switch buttonType {
 		case .abort:
-			button.setTitleColor(XS2AiOS.shared.styleProvider.abortButtonStyle.textColor, for: .normal)
-			button.setBackgroundColor(color: XS2AiOS.shared.styleProvider.abortButtonStyle.backgroundColor, forState: .normal)
-			button.setBackgroundColor(color: XS2AiOS.shared.styleProvider.abortButtonStyle.backgroundColor.lighter(), forState: .highlighted)
+			style = XS2AiOS.shared.styleProvider.abortButtonStyle
 		case .back:
-			button.setTitleColor(XS2AiOS.shared.styleProvider.backButtonStyle.textColor, for: .normal)
-			button.setBackgroundColor(color: XS2AiOS.shared.styleProvider.backButtonStyle.backgroundColor, forState: .normal)
-			button.setBackgroundColor(color: XS2AiOS.shared.styleProvider.backButtonStyle.backgroundColor.lighter(), forState: .highlighted)
+			style = XS2AiOS.shared.styleProvider.backButtonStyle
 		case .restart:
-			button.setTitleColor(XS2AiOS.shared.styleProvider.restartButtonStyle.textColor, for: .normal)
-			button.setBackgroundColor(color: XS2AiOS.shared.styleProvider.restartButtonStyle.backgroundColor, forState: .normal)
-			button.setBackgroundColor(color: XS2AiOS.shared.styleProvider.restartButtonStyle.backgroundColor.lighter(), forState: .highlighted)
+			style = XS2AiOS.shared.styleProvider.restartButtonStyle
 		default:
-			button.setTitleColor(XS2AiOS.shared.styleProvider.submitButtonStyle.textColor, for: .normal)
-			button.setBackgroundColor(color: XS2AiOS.shared.styleProvider.submitButtonStyle.backgroundColor, forState: .normal)
-			button.setBackgroundColor(color: XS2AiOS.shared.styleProvider.submitButtonStyle.backgroundColor.lighter(), forState: .highlighted)
+			style = XS2AiOS.shared.styleProvider.submitButtonStyle
 		}
 
+		button.setTitleColor(style.textColor, for: .normal)
+		button.setBackgroundColor(color: style.backgroundColor, forState: .normal)
+		button.setBackgroundColor(color: style.backgroundColor.lighter(), forState: .highlighted)
+
 		button.layer.cornerRadius = XS2AiOS.shared.styleProvider.buttonBorderRadius
+		button.layer.borderWidth = style.borderWidth
+		button.layer.borderColor = style.borderColor.cgColor
+
 		button.translatesAutoresizingMaskIntoConstraints = false
 		button.titleLabel?.font = XS2AiOS.shared.styleProvider.font.getFont(ofSize: 18, ofWeight: .traitBold)
 		button.heightAnchor.constraint(equalToConstant: 50).isActive = true

--- a/Sources/XS2AiOS/Form Lines/CaptchaLine.swift
+++ b/Sources/XS2AiOS/Form Lines/CaptchaLine.swift
@@ -97,12 +97,13 @@ class CaptchaLine: UIViewController, FormLine, ExposableFormElement, UITextField
 	private func styleTextfield(style: TextFieldStyles) {
 		switch style {
 		case .error:
-			textfieldElement.layer.borderWidth = 2
+			textfieldElement.layer.borderWidth = XS2AiOS.shared.styleProvider.inputBorderWidthActive
 			textfieldElement.layer.borderColor = XS2AiOS.shared.styleProvider.errorStyle.backgroundColor.cgColor
-			textfieldElement.layer.add(getBorderWidthAnimation(type: .didStart), forKey: "Width")
+			textfieldElement.layer.add(getBorderAnimation(type: .didStart), forKey: "Border")
 		default:
-			textfieldElement.layer.borderWidth = 0
-			textfieldElement.layer.add(getBorderWidthAnimation(type: .didEnd), forKey: "Width")
+			textfieldElement.layer.borderColor = XS2AiOS.shared.styleProvider.inputBorderColor.cgColor
+			textfieldElement.layer.borderWidth = XS2AiOS.shared.styleProvider.inputBorderWidth
+			textfieldElement.layer.add(getBorderAnimation(type: .didEnd), forKey: "Border")
 		}
 	}
 }

--- a/Sources/XS2AiOS/Protocols/XS2ATextfield.swift
+++ b/Sources/XS2AiOS/Protocols/XS2ATextfield.swift
@@ -5,14 +5,15 @@ class XS2ATextfield: UITextField {
 	func styleTextfield(style: TextFieldStyles) {
 		switch style {
 		case .error:
-			self.layer.borderWidth = 2
+			self.layer.borderWidth = XS2AiOS.shared.styleProvider.inputBorderWidthActive
 			self.layer.borderColor = XS2AiOS.shared.styleProvider.errorStyle.backgroundColor.cgColor
 			self.layer.add(getBorderWidthAnimation(type: .didStart), forKey: "Width")
 		case .normal:
-			if self.layer.borderWidth != 0 {
-				self.layer.borderWidth = 0
+			if self.layer.borderWidth != XS2AiOS.shared.styleProvider.inputBorderWidth {
+				self.layer.borderWidth = XS2AiOS.shared.styleProvider.inputBorderWidth
 				self.layer.add(getBorderWidthAnimation(type: .didEnd), forKey: "Width")
 			}
+			self.layer.borderColor = XS2AiOS.shared.styleProvider.inputBorderColor.cgColor
 		}
 	}
 	

--- a/Sources/XS2AiOS/Utils/Animation.swift
+++ b/Sources/XS2AiOS/Utils/Animation.swift
@@ -5,19 +5,47 @@ enum BorderAnimationType {
 	case didEnd
 }
 
-func getBorderWidthAnimation(type: BorderAnimationType) -> CABasicAnimation {
+func getBorderWidthAnimation(type: BorderAnimationType) -> CAAnimation {
+
 	let borderWidthAnimation: CABasicAnimation = CABasicAnimation(keyPath: "borderWidth")
-	
+
 	switch type {
 	case .didStart:
-		borderWidthAnimation.fromValue = 0
-		borderWidthAnimation.toValue = 2
+		borderWidthAnimation.fromValue = XS2AiOS.shared.styleProvider.inputBorderWidth
+		borderWidthAnimation.toValue = XS2AiOS.shared.styleProvider.inputBorderWidthActive
 	case .didEnd:
-		borderWidthAnimation.fromValue = 2
-		borderWidthAnimation.toValue = 0
+		borderWidthAnimation.fromValue = XS2AiOS.shared.styleProvider.inputBorderWidthActive
+		borderWidthAnimation.toValue = XS2AiOS.shared.styleProvider.inputBorderWidth
 	}
-	
+
 	borderWidthAnimation.duration = 0.15
-	
+
 	return borderWidthAnimation
+}
+
+func getBorderColorAnimation(type: BorderAnimationType) -> CAAnimation {
+
+	let animation: CABasicAnimation = CABasicAnimation(keyPath: "borderColor")
+
+	switch type {
+	case .didStart:
+		animation.fromValue = XS2AiOS.shared.styleProvider.inputBorderColor.cgColor
+		animation.toValue = XS2AiOS.shared.styleProvider.tintColor.cgColor
+	case .didEnd:
+		animation.fromValue = XS2AiOS.shared.styleProvider.tintColor.cgColor
+		animation.toValue = XS2AiOS.shared.styleProvider.inputBorderColor.cgColor
+	}
+
+	animation.duration = 0.15
+
+	return animation
+}
+
+func getBorderAnimation(type: BorderAnimationType) -> CAAnimation {
+
+	let group = CAAnimationGroup()
+	group.animations = [getBorderWidthAnimation(type: type), getBorderColorAnimation(type: type)]
+	group.duration = 0.15
+
+	return group
 }

--- a/Sources/XS2AiOS/Utils/Animation.swift
+++ b/Sources/XS2AiOS/Utils/Animation.swift
@@ -6,7 +6,6 @@ enum BorderAnimationType {
 }
 
 func getBorderWidthAnimation(type: BorderAnimationType) -> CAAnimation {
-
 	let borderWidthAnimation: CABasicAnimation = CABasicAnimation(keyPath: "borderWidth")
 
 	switch type {
@@ -24,7 +23,6 @@ func getBorderWidthAnimation(type: BorderAnimationType) -> CAAnimation {
 }
 
 func getBorderColorAnimation(type: BorderAnimationType) -> CAAnimation {
-
 	let animation: CABasicAnimation = CABasicAnimation(keyPath: "borderColor")
 
 	switch type {
@@ -42,7 +40,6 @@ func getBorderColorAnimation(type: BorderAnimationType) -> CAAnimation {
 }
 
 func getBorderAnimation(type: BorderAnimationType) -> CAAnimation {
-
 	let group = CAAnimationGroup()
 	group.animations = [getBorderWidthAnimation(type: type), getBorderColorAnimation(type: type)]
 	group.duration = 0.15

--- a/Sources/XS2AiOS/XS2AiOS.swift
+++ b/Sources/XS2AiOS/XS2AiOS.swift
@@ -131,6 +131,9 @@ extension XS2AiOS {
 		/// Textfield Styles
 		var inputBackgroundColor: UIColor
 		var inputBorderRadius: CGFloat
+		var inputBorderColor: UIColor
+		var inputBorderWidth: CGFloat
+		var inputBorderWidthActive: CGFloat
 		var inputTextColor: UIColor
 		var placeholderColor: UIColor
 		
@@ -161,6 +164,9 @@ extension XS2AiOS {
 			textColor: UIColor = UIColor(red: 0.15, green: 0.15, blue: 0.15, alpha: 1),
 			inputBackgroundColor: UIColor = UIColor(red: 0.96, green: 0.97, blue: 0.98, alpha: 1.00),
 			inputBorderRadius: CGFloat = 6,
+			inputBorderColor: UIColor = .clear,
+			inputBorderWidth: CGFloat = 0,
+			inputBorderWidthActive: CGFloat = 2,
 			inputTextColor: UIColor = UIColor(red: 0.15, green: 0.15, blue: 0.15, alpha: 1),
 			placeholderColor: UIColor = UIColor(red: 0.5, green: 0.5, blue: 0.5, alpha: 1.00),
 			buttonBorderRadius: CGFloat = 6,
@@ -180,6 +186,9 @@ extension XS2AiOS {
 			self.textColor = textColor
 			self.inputBackgroundColor = inputBackgroundColor
 			self.inputBorderRadius = inputBorderRadius
+			self.inputBorderColor = inputBorderColor
+			self.inputBorderWidth = inputBorderWidth
+			self.inputBorderWidthActive = inputBorderWidthActive
 			self.inputTextColor = inputTextColor
 			self.placeholderColor = placeholderColor
 			self.buttonBorderRadius = buttonBorderRadius

--- a/Sources/XS2AiOS/XS2AiOS.swift
+++ b/Sources/XS2AiOS/XS2AiOS.swift
@@ -103,10 +103,14 @@ extension XS2AiOS {
 	public struct ButtonStyle {
 		var textColor: UIColor
 		var backgroundColor: UIColor
+		var borderWidth: CGFloat
+		var borderColor: UIColor
 		
-		public init(textColor: UIColor, backgroundColor: UIColor) {
+		public init(textColor: UIColor, backgroundColor: UIColor, borderWidth: CGFloat = 0, borderColor: UIColor = .clear) {
 			self.textColor = textColor
 			self.backgroundColor = backgroundColor
+			self.borderWidth = borderWidth
+			self.borderColor = borderColor
 		}
 	}
 	


### PR DESCRIPTION
Extend the Style Provider to define the color and width of the border around the text fields and buttons.

Here is the example of UI i want to achieve with extended style:
<img width="398" alt="Screenshot 2022-09-21 at 23 09 34" src="https://user-images.githubusercontent.com/1951671/191683764-09de8ffe-13cc-40ea-9323-3307b2dcf2f8.png">
<img width="404" alt="Screenshot 2022-09-21 at 23 09 54" src="https://user-images.githubusercontent.com/1951671/191683771-b858a365-f175-43d3-bfdd-7dacae1efbb3.png">
