### PR TITLE
Add possibility to hide back button in form and implement external one

### DIFF
--- a/Sources/XS2AiOS/Utils/ResponseDecoder.swift
+++ b/Sources/XS2AiOS/Utils/ResponseDecoder.swift
@@ -98,8 +98,8 @@ func decodeJSON(json: JSON, indexOffset: Int? = 0) -> [FormLine] {
 							actionType: .submit
 						)
 					)
-					
-					if formElement["back"].string != nil {
+
+					if XS2AiOS.shared.configuration.enableBackButton && formElement["back"].string != nil {
 						formClasses.append(
 							SubmitLine(
 								label: formElement["back"].stringValue,
@@ -107,6 +107,7 @@ func decodeJSON(json: JSON, indexOffset: Int? = 0) -> [FormLine] {
 							)
 						)
 					}
+					XS2AiOS.shared.backButtonIsPresent = formElement["back"].string != nil
 				case .restart:
 					formClasses.append(
 						RestartLine(
@@ -159,7 +160,7 @@ func decodeJSON(json: JSON, indexOffset: Int? = 0) -> [FormLine] {
 						)
 					)
 					
-					if formElement["back"].string != nil {
+					if XS2AiOS.shared.configuration.enableBackButton && formElement["back"].string != nil {
 						formClasses.append(
 							SubmitLine(
 								label: formElement["back"].stringValue,
@@ -167,6 +168,7 @@ func decodeJSON(json: JSON, indexOffset: Int? = 0) -> [FormLine] {
 							)
 						)
 					}
+					XS2AiOS.shared.backButtonIsPresent = formElement["back"].string != nil
 				case .hidden:
 					formClasses.append(
 						HiddenLine(

--- a/Sources/XS2AiOS/XS2AViewController.swift
+++ b/Sources/XS2AiOS/XS2AViewController.swift
@@ -688,7 +688,18 @@ public class XS2AViewController: UIViewController, UIAdaptivePresentationControl
 		/// Set back to regular inset
 		scrollView.contentInset = .zero
 	}
-	
+
+	/// Tells the server to go one step back and calls `backButtonAction` if supplied but only if a back button is present.
+	public func goBack() {
+		if !backButtonIsPresent { return }
+		sendAction(actionType: .back, withLoadingIndicator: false, additionalPayload: nil)
+	}
+
+	/// Returns `true` if a back button is present on the current form.
+	public var backButtonIsPresent: Bool {
+		XS2AiOS.shared.backButtonIsPresent
+	}
+
 	/// Function called when the user tries to dismiss this ViewController
 	public func presentationControllerDidAttemptToDismiss(_ presentationController: UIPresentationController) {
 		showAbortAlert()

--- a/Sources/XS2AiOS/XS2AiOS.swift
+++ b/Sources/XS2AiOS/XS2AiOS.swift
@@ -9,7 +9,8 @@ public class XS2AiOS {
 	public let loadingStateProvider: LoadingStateProvider
 	public let keychain: Keychain
 	let apiService: APIService
-	
+	var backButtonIsPresent: Bool = false
+
 	public var currentStep: WizardStep? {
 		didSet {
 			XS2AiOS.shared.configuration.onStepChanged(currentStep)
@@ -79,13 +80,15 @@ extension XS2AiOS {
 		var onStepChanged: (WizardStep?) -> Void
 		var baseURL: String
 		var language: Language?
+		var enableBackButton: Bool
 		
 		public init(
 			wizardSessionKey: String,
 			backButtonAction: @escaping () -> Void = {},
 			onStepChanged: @escaping (WizardStep?) -> Void = {_ in },
 			baseURL: String = "https://api.xs2a.com/jsonp",
-			language: Language? = nil
+			language: Language? = nil,
+			enableBackButton: Bool = true
 		) {
 			self.wizardSessionKey = wizardSessionKey
 			self.permissionToStoreCredentials = false
@@ -97,6 +100,7 @@ extension XS2AiOS {
 			if let language = language {
 				self.language = language
 			}
+			self.enableBackButton = enableBackButton
 		}
 	}
 	


### PR DESCRIPTION
This change enables me to trigger back navigation between Form pages with back button displayed in navigation bar.
This PR:
* Adds new config property `enableBackButton` that decides if back buttons are rendered in Form.
* Adds public `goBack` method that allows triggering back button action from outside.

It's the same change as the one made in Android SDK:
https://github.com/FinTecSystems/xs2a-android/commit/9ed72810af90ac3c64461ace272e40d2ebee8c6b
https://github.com/FinTecSystems/xs2a-android/commit/f7443f1326fb688ee978cee167b02f0519e95af8